### PR TITLE
fix TypeEntity issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.application'
     id 'kotlin-android'
+    id 'org.jetbrains.kotlin.plugin.serialization' version '1.5.31'
 }
 
 android {
@@ -51,6 +52,7 @@ android {
 
 apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
+apply plugin: 'kotlinx-serialization'
 
 dependencies {
     implementation "androidx.compose.ui:ui:$compose_version"
@@ -61,6 +63,8 @@ dependencies {
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 
+
+    implementation "org.jetbrains.kotlinx:kotlinx-serialization-json:1.0.1"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.6.0'

--- a/app/src/main/java/fr/legris/pokedex/data/bdd/AppDatabase.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/bdd/AppDatabase.kt
@@ -1,14 +1,13 @@
 package fr.legris.pokedex.data.bdd
 
 import android.content.Context
-import androidx.room.Database
-import androidx.room.Room
-import androidx.room.RoomDatabase
+import androidx.room.*
 import fr.legris.pokedex.data.bdd.dao.PokemonDao
 import fr.legris.pokedex.data.bdd.dao.PokemonFromListDao
 import fr.legris.pokedex.data.bdd.model.PokemonEntity
 
-@Database(entities = [PokemonEntity::class], version = 1)
+@Database(entities = [PokemonEntity::class], version = 1, exportSchema = false)
+@TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun pokemonFromListDao(): PokemonFromListDao
     abstract fun pokemonDao(): PokemonDao

--- a/app/src/main/java/fr/legris/pokedex/data/bdd/Converters.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/bdd/Converters.kt
@@ -1,0 +1,15 @@
+package fr.legris.pokedex.data.bdd
+
+import androidx.room.TypeConverter
+import fr.legris.pokedex.data.bdd.model.TypeEntity
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+
+class Converters {
+    @TypeConverter
+    fun fromList(value : List<TypeEntity>) = Json.encodeToString(value)
+
+    @TypeConverter
+    fun toList(value: String) = Json.decodeFromString<List<TypeEntity>>(value)
+}

--- a/app/src/main/java/fr/legris/pokedex/data/bdd/model/TypeEntity.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/bdd/model/TypeEntity.kt
@@ -1,7 +1,9 @@
 package fr.legris.pokedex.data.bdd.model
 
 import androidx.room.ColumnInfo
+import kotlinx.serialization.Serializable
 
+@Serializable
 data class TypeEntity(
     @ColumnInfo(name = "slot") val slot : Int,
     @ColumnInfo(name = "name") val name : String

--- a/app/src/main/java/fr/legris/pokedex/data/mappers/DbEntityMapper.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/mappers/DbEntityMapper.kt
@@ -2,6 +2,10 @@ package fr.legris.pokedex.data.mappers
 
 interface DbEntityMapper<DbEntity, ApiModel, ModelUi> {
     fun mapFromApiModel(apiModel: ApiModel): DbEntity
-    fun mapFromApiModelList(apiModelList: List<ApiModel>): List<DbEntity>
+    fun mapFromApiModelList(apiModelList: List<ApiModel>): List<DbEntity> {
+        return apiModelList.map {
+            mapFromApiModel(it)
+        }
+    }
     fun mapFromDbEntityToModelUi(dbEntity: DbEntity): ModelUi
 }

--- a/app/src/main/java/fr/legris/pokedex/data/mappers/PokemonListMapper.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/mappers/PokemonListMapper.kt
@@ -12,7 +12,8 @@ class PokemonListMapper: DbEntityMapper<PokemonEntity, PokemonFromListDTO, Pokem
         return PokemonEntity(
             id,
             apiModel.name,
-            "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png"
+            "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png",
+            emptyList()
         )
     }
 

--- a/app/src/main/java/fr/legris/pokedex/data/mappers/PokemonListMapper.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/mappers/PokemonListMapper.kt
@@ -1,6 +1,5 @@
 package fr.legris.pokedex.data.mappers
 
-import androidx.compose.ui.text.intl.Locale
 import fr.legris.pokedex.data.api.model.PokemonFromListDTO
 import fr.legris.pokedex.data.bdd.model.PokemonEntity
 import fr.legris.pokedex.ui.model.PokemonFromList
@@ -15,12 +14,6 @@ class PokemonListMapper: DbEntityMapper<PokemonEntity, PokemonFromListDTO, Pokem
             "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${id}.png",
             emptyList()
         )
-    }
-
-    override fun mapFromApiModelList(apiModelList: List<PokemonFromListDTO>): List<PokemonEntity>  {
-        return apiModelList.map { pokemon ->
-            mapFromApiModel(pokemon)
-        }
     }
 
     override fun mapFromDbEntityToModelUi(dbEntity: PokemonEntity): PokemonFromList {

--- a/app/src/main/java/fr/legris/pokedex/data/mappers/PokemonMapper.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/mappers/PokemonMapper.kt
@@ -1,26 +1,20 @@
 package fr.legris.pokedex.data.mappers
 
 import fr.legris.pokedex.data.api.model.PokemonDTO
-import fr.legris.pokedex.data.api.model.TypesDTO
 import fr.legris.pokedex.data.bdd.model.PokemonEntity
-import fr.legris.pokedex.data.bdd.model.TypeEntity
 import fr.legris.pokedex.ui.model.Pokemon
-import fr.legris.pokedex.ui.model.Type
 
 class PokemonMapper : DbEntityMapper<PokemonEntity, PokemonDTO, Pokemon> {
+
+    private val typeMapper = TypeMapper()
+
     override fun mapFromApiModel(apiModel: PokemonDTO): PokemonEntity {
         return PokemonEntity(
             apiModel.id,
             apiModel.name,
             apiModel.spritesDTO.front_default,
-            apiModel.types.map { mapTypeDTOToTypeEntity(it) }
+            apiModel.types.map { typeMapper.mapFromApiModel(it) }
         )
-    }
-
-    override fun mapFromApiModelList(apiModelList: List<PokemonDTO>): List<PokemonEntity> {
-        return apiModelList.map {
-            mapFromApiModel(it)
-        }
     }
 
     override fun mapFromDbEntityToModelUi(dbEntity: PokemonEntity): Pokemon {
@@ -29,18 +23,7 @@ class PokemonMapper : DbEntityMapper<PokemonEntity, PokemonDTO, Pokemon> {
             dbEntity.id,
             name,
             dbEntity.mainPictureUrl,
-            dbEntity.typeEntities.map { mapTypeEntityToModelUi(it) }
+            dbEntity.typeEntities.map { typeMapper.mapFromDbEntityToModelUi(it) }
         )
-    }
-
-    private fun mapTypeDTOToTypeEntity(typesDto : TypesDTO) : TypeEntity{
-        return TypeEntity(
-            typesDto.slot,
-            typesDto.typeDTO.name
-        )
-    }
-
-    private fun mapTypeEntityToModelUi(typeEntity: TypeEntity) : Type{
-        return Type.values().firstOrNull { typeEnum -> typeEntity.name == typeEnum.name } ?: Type.UNKNOWN
     }
 }

--- a/app/src/main/java/fr/legris/pokedex/data/mappers/TypeMapper.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/mappers/TypeMapper.kt
@@ -1,0 +1,20 @@
+package fr.legris.pokedex.data.mappers
+
+import fr.legris.pokedex.data.api.model.TypesDTO
+import fr.legris.pokedex.data.bdd.model.TypeEntity
+import fr.legris.pokedex.ui.model.Type
+
+class TypeMapper : DbEntityMapper<TypeEntity, TypesDTO, Type> {
+
+    override fun mapFromApiModel(apiModel: TypesDTO): TypeEntity {
+        return TypeEntity(
+            apiModel.slot,
+            apiModel.typeDTO.name
+        )
+    }
+
+    override fun mapFromDbEntityToModelUi(dbEntity: TypeEntity): Type {
+        return Type.values().firstOrNull { typeEnum -> dbEntity.name == typeEnum.name }
+            ?: Type.UNKNOWN
+    }
+}

--- a/app/src/main/java/fr/legris/pokedex/data/repository/PokemonRepositoryImpl.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/repository/PokemonRepositoryImpl.kt
@@ -42,11 +42,12 @@ class PokemonRepositoryImpl @Inject constructor(
 
     override fun getPokemonById(id: Int): LiveData<Resource<Pokemon>> {
         return performGetOperation(
-        databaseQuery = { pokemonDao.findById(id) },
-        networkCall = { getResult { pokemonService.getPokemonById(id) } },
-        saveCallResult = { pokemonDao.insert(PokemonMapper().mapFromApiModel(it)) },
-        mapper = PokemonMapper()
-    )}
+            databaseQuery = { pokemonDao.findById(id) },
+            networkCall = { getResult { pokemonService.getPokemonById(id) } },
+            saveCallResult = { pokemonDao.insert(PokemonMapper().mapFromApiModel(it)) },
+            mapper = PokemonMapper()
+        )
+    }
 
     private suspend fun <T> getResult(call: suspend () -> Response<T>): Resource<T> {
         try {

--- a/app/src/main/java/fr/legris/pokedex/data/repository/PokemonRepositoryImpl.kt
+++ b/app/src/main/java/fr/legris/pokedex/data/repository/PokemonRepositoryImpl.kt
@@ -41,11 +41,12 @@ class PokemonRepositoryImpl @Inject constructor(
     }
 
     override fun getPokemonById(id: Int): LiveData<Resource<Pokemon>> {
+        val pokemonMapper = PokemonMapper()
         return performGetOperation(
             databaseQuery = { pokemonDao.findById(id) },
             networkCall = { getResult { pokemonService.getPokemonById(id) } },
-            saveCallResult = { pokemonDao.insert(PokemonMapper().mapFromApiModel(it)) },
-            mapper = PokemonMapper()
+            saveCallResult = { pokemonDao.insert(pokemonMapper.mapFromApiModel(it)) },
+            mapper = pokemonMapper
         )
     }
 


### PR DESCRIPTION
J'avais cette erreur-ci :

```
C:\workspace-baptiste\pokedex\app\build\tmp\kapt3\stubs\debug\fr\legris\pokedex\data\bdd\model\PokemonEntity.java:18: error: Cannot figure out how to save this field into database. You can consider adding a type converter for it.
    private final java.util.List<fr.legris.pokedex.data.bdd.model.TypeEntity> typeEntities = null;
                                                                              ^
C:\workspace-baptiste\pokedex\app\build\tmp\kapt3\stubs\debug\fr\legris\pokedex\data\bdd\model\PokemonEntity.java:18: error: Cannot figure out how to read this field from a cursor.
    private final java.util.List<fr.legris.pokedex.data.bdd.model.TypeEntity> typeEntities = null;
                                                                              ^
C:\workspace-baptiste\pokedex\app\build\tmp\kapt3\stubs\debug\fr\legris\pokedex\data\bdd\AppDatabase.java:7: warning: Schema export directory is not provided to the annotation processor so we cannot export the schema. You can either provide `room.schemaLocation` annotation processor argument OR set exportSchema to false.
public abstract class AppDatabase extends androidx.room.RoomDatabase {
```